### PR TITLE
Add Fun Facts utility with toast notifications (bump to 6.6)

### DIFF
--- a/Waddle.js
+++ b/Waddle.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Waddle
 // @namespace    https://github.com/TheM1ddleM1n/Waddle
-// @version      6.5
+// @version      6.6
 // @description  The ultimate Miniblox enhancement suite with advanced API features!
 // @author       The Dream Team! (Scripter & TheM1ddleM1n)
 // @icon         https://raw.githubusercontent.com/TheM1ddleM1n/Waddle/refs/heads/main/Penguin.png
@@ -9,7 +9,7 @@
 // @run-at       document-start
 // ==/UserScript==
 
-const SCRIPT_VERSION = '6.5';
+const SCRIPT_VERSION = '6.6';
 
 (function () {
   'use strict';
@@ -48,9 +48,19 @@ const SCRIPT_VERSION = '6.5';
     ],
     utilities: [
       { label: 'Anti-AFK', feature: 'antiAfk' },
+      { label: 'Fun Facts', feature: 'funFacts' },
       { label: 'Block Party RQ', feature: 'disablePartyRequests' }
     ]
   };
+
+  const FUN_FACTS = [
+    'Penguins can drink seawater thanks to a special gland above their eyes.',
+    'A group of penguins in the water is called a raft.',
+    'Emperor penguins are the tallest penguin species on Earth.',
+    'Some penguin species can dive deeper than 500 meters.',
+    'Penguins use their wings as powerful flippers to swim.',
+    'Many penguins slide on their bellies across ice to save energy.'
+  ];
 
   // ─── gameRef ─────────────────────────────────────────────────────────────────
   const gameRef = {
@@ -97,7 +107,8 @@ const SCRIPT_VERSION = '6.5';
   let state = {
     features: {
       performance: false, coords: false, realTime: false,
-      antiAfk: false, keyDisplay: false, disablePartyRequests: false
+      antiAfk: false, keyDisplay: false, disablePartyRequests: false,
+      funFacts: false
     },
     counters: { performance: null, realTime: null, coords: null, antiAfk: null, keyDisplay: null },
     menuOverlay: null,
@@ -980,6 +991,21 @@ const SCRIPT_VERSION = '6.5';
       cleanup: () => {
         clearInterval(state.intervals.partyRetry); state.intervals.partyRetry = null;
         restorePartyRequests();
+      }
+    },
+    funFacts: {
+      start: () => {
+        if (state.intervals.funFacts) return;
+        const showRandomFact = () => {
+          const fact = FUN_FACTS[Math.floor(Math.random() * FUN_FACTS.length)];
+          showToast('🐧 Fun Fact', 'info', fact);
+        };
+        showRandomFact();
+        state.intervals.funFacts = setInterval(showRandomFact, 60000);
+      },
+      cleanup: () => {
+        clearInterval(state.intervals.funFacts);
+        state.intervals.funFacts = null;
       }
     }
   };


### PR DESCRIPTION
### Motivation
- Provide a light, opt-in way to surface fun penguin facts to users via the existing toast UI so the overlay feels more personable.

### Description
- Bumped userscript metadata and runtime constant from `6.5` to `6.6`.
- Added a `FUN_FACTS` array and a persisted `funFacts` flag in `state.features` so the toggle is saved alongside other modules.
- Added the `Fun Facts` entry to the `utilities` panel in `FEATURE_MAP` and implemented `featureManager.funFacts` which shows an immediate toast via `showToast` and then rotates random facts every 60s while enabled.
- Ensured cleanup clears the interval in `state.intervals.funFacts` when the feature is disabled so no timers leak.

### Testing
- Ran `node --check Waddle.js` which completed without errors.
- Executed a headless browser script to capture a page screenshot as contextual validation which completed successfully.
- Verified the change was committed to the repository (`Waddle.js` modified and committed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4ae18b96c83308d35c08c7c334202)