### PR TITLE
Add togglable 'Fun Facts' feature and bump script to v6.7

### DIFF
--- a/Waddle.js
+++ b/Waddle.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Waddle
 // @namespace    https://github.com/TheM1ddleM1n/Waddle
-// @version      6.5
+// @version      6.7
 // @description  The ultimate Miniblox enhancement suite with advanced API features!
 // @author       The Dream Team! (Scripter & TheM1ddleM1n)
 // @icon         https://raw.githubusercontent.com/TheM1ddleM1n/Waddle/refs/heads/main/Penguin.png
@@ -9,7 +9,7 @@
 // @run-at       document-start
 // ==/UserScript==
 
-const SCRIPT_VERSION = '6.5';
+const SCRIPT_VERSION = '6.7';
 
 (function () {
   'use strict';
@@ -48,9 +48,19 @@ const SCRIPT_VERSION = '6.5';
     ],
     utilities: [
       { label: 'Anti-AFK', feature: 'antiAfk' },
+      { label: 'Fun Facts', feature: 'funFacts' },
       { label: 'Block Party RQ', feature: 'disablePartyRequests' }
     ]
   };
+
+  const FUN_FACTS = [
+    'Penguins can drink seawater thanks to a special gland above their eyes.',
+    'A group of penguins in the water is called a raft.',
+    'Emperor penguins are the tallest penguin species on Earth.',
+    'Some penguin species can dive deeper than 500 meters.',
+    'Penguins use their wings as powerful flippers to swim.',
+    'Many penguins slide on their bellies across ice to save energy.'
+  ];
 
   // ─── gameRef ─────────────────────────────────────────────────────────────────
   const gameRef = {
@@ -97,7 +107,8 @@ const SCRIPT_VERSION = '6.5';
   let state = {
     features: {
       performance: false, coords: false, realTime: false,
-      antiAfk: false, keyDisplay: false, disablePartyRequests: false
+      antiAfk: false, keyDisplay: false, disablePartyRequests: false,
+      funFacts: false
     },
     counters: { performance: null, realTime: null, coords: null, antiAfk: null, keyDisplay: null },
     menuOverlay: null,
@@ -980,6 +991,28 @@ const SCRIPT_VERSION = '6.5';
       cleanup: () => {
         clearInterval(state.intervals.partyRetry); state.intervals.partyRetry = null;
         restorePartyRequests();
+      }
+    },
+    funFacts: {
+      start: () => {
+        if (state.intervals.funFacts) return;
+        let wasInGame = false;
+        const showRandomFact = () => {
+          const fact = FUN_FACTS[Math.floor(Math.random() * FUN_FACTS.length)];
+          showToast('🐧 Fun Fact', 'info', fact);
+        };
+        const watchInGame = () => {
+          const paused = !!document.querySelector('.chakra-modal__content-container,[role="dialog"]');
+          const inGame = !!(document.pointerLockElement && !paused);
+          if (inGame && !wasInGame) showRandomFact();
+          wasInGame = inGame;
+        };
+        watchInGame();
+        state.intervals.funFacts = setInterval(watchInGame, 500);
+      },
+      cleanup: () => {
+        clearInterval(state.intervals.funFacts);
+        state.intervals.funFacts = null;
       }
     }
   };


### PR DESCRIPTION
### Motivation
- Introduce a light, optionally-enabled HUD feature that periodically shows random penguin-related facts while the player is in-game. 
- Prepare the release bump to reflect the new feature and ensure settings migrate cleanly with the expanded feature set.

### Description
- Bump userscript metadata and `SCRIPT_VERSION` from `6.5` to `6.7`.
- Add a `FUN_FACTS` array with several penguin facts and register the feature in `FEATURE_MAP` and `state.features` so it can be toggled from the menu.
- Implement `featureManager.funFacts` with a `start` handler that watches whether the user is in-game (using pointer lock and modal detection) and shows a random fact via `showToast`, and a `cleanup` handler that clears the interval.

### Testing
- No automated tests are present for this project, so no CI or unit tests were run against these changes.
- Basic static/compilation surface was left intact and no test failures were reported by local sanity checks.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4ae18b96c83308d35c08c7c334202)