### PR TITLE
Fix feature toggle state when startup fails

### DIFF
--- a/Waddle.js
+++ b/Waddle.js
@@ -1244,13 +1244,18 @@ const SCRIPT_VERSION = '6.12';
   });
 
   function toggleFeature(featureName) {
-    const enabled = !state.features[featureName];
-    state.features[featureName] = enabled;
-    if (enabled) featureManager[featureName]?.start();
-    else featureManager[featureName]?.cleanup();
+    const requestedEnabled = !state.features[featureName];
+    state.features[featureName] = requestedEnabled;
+    if (requestedEnabled) {
+      const startResult = featureManager[featureName]?.start?.();
+      if (startResult === false || !state.features[featureName]) state.features[featureName] = false;
+    } else {
+      featureManager[featureName]?.cleanup?.();
+      state.features[featureName] = false;
+    }
     saveSettings();
     refreshHud();
-    return enabled;
+    return state.features[featureName];
   }
 
   function buildSkinPanel() {


### PR DESCRIPTION
### Motivation
- Prevent UI/logic mismatch where a feature could remain marked enabled even when its `start()` failed or the feature self-reverted due to missing prerequisites.

### Description
- Change `toggleFeature` to apply the requested state, call `featureManager[feature].start()` and treat an explicit `false` return or an immediate internal revert as a real failure (force the flag back to `false`), and ensure cleanup uses optional chaining and explicitly disables the flag; return the actual persisted state from the function.

### Testing
- Ran `node --check Waddle.js` to validate syntax which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b07295997883308ca5b4f2ed17d4cb)