### PR TITLE
Fix chat mute reapply flow

### DIFF
--- a/Waddle.js
+++ b/Waddle.js
@@ -230,6 +230,7 @@ const SCRIPT_VERSION = '6.16';
     _lastSpeedPos: null,
     _lastSpeedTime: 0,
     _lastPing: 0,
+    _mutedChat: null,
   };
 
   const KNOWN_FEATURES = new Set(Object.keys(state.features));
@@ -1063,6 +1064,23 @@ const SCRIPT_VERSION = '6.16';
     }
   }
 
+  function applyChatMute(game) {
+    if (!game?.chat) return false;
+    if (game.chat !== state._mutedChat) restoreMutedChat();
+    if (!game.chat._waddleOriginalAddChat) game.chat._waddleOriginalAddChat = game.chat.addChat.bind(game.chat);
+    game.chat.addChat = function () {};
+    state._mutedChat = game.chat;
+    return true;
+  }
+
+  function restoreMutedChat() {
+    if (state._mutedChat?._waddleOriginalAddChat) {
+      state._mutedChat.addChat = state._mutedChat._waddleOriginalAddChat;
+      delete state._mutedChat._waddleOriginalAddChat;
+    }
+    state._mutedChat = null;
+  }
+
   const featureManager = {
     performance: {
       start() {
@@ -1188,18 +1206,20 @@ const SCRIPT_VERSION = '6.16';
     },
     muteChat: {
       start() {
-        const game = gameRef.get();
-        if (!game?.chat) { showToast('Chat Mute', 'disabled', 'Game not loaded yet!'); state.features.muteChat = false; return; }
-        if (!game.chat._waddleOriginalAddChat) game.chat._waddleOriginalAddChat = game.chat.addChat.bind(game.chat);
-        game.chat.addChat = function () {};
+        const tryMute = () => applyChatMute(gameRef.get());
+        const mutedImmediately = tryMute();
+        clearInterval(state.intervals.chatMuteRetry);
+        state.intervals.chatMuteRetry = setInterval(tryMute, 2000);
+        if (!mutedImmediately) {
+          showToast('Chat-Mute', 'info', 'Waiting for game chat to load...');
+          return;
+        }
         showToast('Chat-Mute', 'enabled', 'Chat messages are now hidden');
       },
       cleanup() {
-        const game = gameRef.get();
-        if (game?.chat?._waddleOriginalAddChat) {
-          game.chat.addChat = game.chat._waddleOriginalAddChat;
-          delete game.chat._waddleOriginalAddChat;
-        }
+        clearInterval(state.intervals.chatMuteRetry);
+        state.intervals.chatMuteRetry = null;
+        restoreMutedChat();
         showToast('Chat-Mute', 'disabled', 'Chat messages restored');
       }
     },


### PR DESCRIPTION
### Motivation
- The Chat-Mute feature could not be enabled before the game's chat object was available and would lose its patch when the game/chat instance changed, allowing messages to reappear while the UI still showed the feature enabled.

### Description
- Add `state._mutedChat` to track the currently patched chat instance so stale patches are avoided.
- Introduce `applyChatMute(game)` and `restoreMutedChat()` helpers to centralize patch and restore logic for chat muting.
- Change the `muteChat` feature to retry applying the mute via a `state.intervals.chatMuteRetry` interval until the game's chat loads and to reapply the patch when the chat instance changes.
- Ensure cleanup clears the retry interval and restores the original chat handler reliably.

### Testing
- Ran `node --check Waddle.js` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bb1fdf44908330b473fceacd24e1c1)