### PR TITLE
Add robust chat-mute handling and minor HUD behavior fixes

### DIFF
--- a/Waddle.js
+++ b/Waddle.js
@@ -230,6 +230,7 @@ const SCRIPT_VERSION = '6.16';
     _lastSpeedPos: null,
     _lastSpeedTime: 0,
     _lastPing: 0,
+    _mutedChat: null,
   };
 
   const KNOWN_FEATURES = new Set(Object.keys(state.features));
@@ -802,6 +803,9 @@ const SCRIPT_VERSION = '6.16';
 
     if (type === 'performance') {
       buildFpsCpsContent(wrap);
+      wrap.style.borderColor = state.lastPerformanceColor;
+      const fpsEl = wrap.querySelector('#fps-val');
+      if (fpsEl) fpsEl.style.color = state.lastPerformanceColor;
     } else if (type === 'keyDisplay') {
       buildKeyDisplayContent(wrap);
     } else {
@@ -1063,6 +1067,23 @@ const SCRIPT_VERSION = '6.16';
     }
   }
 
+  function applyChatMute(game) {
+    if (!game?.chat) return false;
+    if (game.chat !== state._mutedChat) restoreMutedChat();
+    if (!game.chat._waddleOriginalAddChat) game.chat._waddleOriginalAddChat = game.chat.addChat.bind(game.chat);
+    game.chat.addChat = function () {};
+    state._mutedChat = game.chat;
+    return true;
+  }
+
+  function restoreMutedChat() {
+    if (state._mutedChat?._waddleOriginalAddChat) {
+      state._mutedChat.addChat = state._mutedChat._waddleOriginalAddChat;
+      delete state._mutedChat._waddleOriginalAddChat;
+    }
+    state._mutedChat = null;
+  }
+
   const featureManager = {
     performance: {
       start() {
@@ -1188,18 +1209,20 @@ const SCRIPT_VERSION = '6.16';
     },
     muteChat: {
       start() {
-        const game = gameRef.get();
-        if (!game?.chat) { showToast('Chat Mute', 'disabled', 'Game not loaded yet!'); state.features.muteChat = false; return; }
-        if (!game.chat._waddleOriginalAddChat) game.chat._waddleOriginalAddChat = game.chat.addChat.bind(game.chat);
-        game.chat.addChat = function () {};
+        const tryMute = () => applyChatMute(gameRef.get());
+        const mutedImmediately = tryMute();
+        clearInterval(state.intervals.chatMuteRetry);
+        state.intervals.chatMuteRetry = setInterval(tryMute, 2000);
+        if (!mutedImmediately) {
+          showToast('Chat-Mute', 'info', 'Waiting for game chat to load...');
+          return;
+        }
         showToast('Chat-Mute', 'enabled', 'Chat messages are now hidden');
       },
       cleanup() {
-        const game = gameRef.get();
-        if (game?.chat?._waddleOriginalAddChat) {
-          game.chat.addChat = game.chat._waddleOriginalAddChat;
-          delete game.chat._waddleOriginalAddChat;
-        }
+        clearInterval(state.intervals.chatMuteRetry);
+        state.intervals.chatMuteRetry = null;
+        restoreMutedChat();
         showToast('Chat-Mute', 'disabled', 'Chat messages restored');
       }
     },
@@ -1209,9 +1232,18 @@ const SCRIPT_VERSION = '6.16';
     featureManager[f] = {
       start() {
         if (!state.counters[f]) createWidget(f);
+        if (f === 'speedometer') {
+          state._lastSpeedPos = null;
+          state._lastSpeedTime = 0;
+          updateCounterText('speedometer', '⚡ 0.00 b/s');
+        }
         startPerformanceLoop();
       },
       cleanup() {
+        if (f === 'speedometer') {
+          state._lastSpeedPos = null;
+          state._lastSpeedTime = 0;
+        }
         removeCounter(f);
         if (!needsRaf()) stopPerformanceLoop();
       }


### PR DESCRIPTION
### Motivation

- Make chat muting more robust by handling cases where the game chat is not yet available and by preserving/restoring original chat behavior. 
- Ensure the performance widget reflects the last known color state and that the speedometer initializes/resets correctly when toggled. 
- Reduce fragile direct mutations by centralizing mute/restore logic and adding a retry mechanism.

### Description

- Added `state._mutedChat` plus two helper functions `applyChatMute` and `restoreMutedChat` to encapsulate chat override and restoration. 
- Reworked the `muteChat` feature to attempt muting immediately and fall back to retrying via `state.intervals.chatMuteRetry`, and updated toasts to indicate waiting/enabled/disabled states. 
- Updated creation of the `performance` widget to set `wrap.style.borderColor` and the `#fps-val` color from `state.lastPerformanceColor`. 
- Initialized and reset speedometer tracking values (`state._lastSpeedPos` and `state._lastSpeedTime`) and set an initial display of `⚡ 0.00 b/s` when the `speedometer` feature starts and clears them on cleanup. 

### Testing

- Ran the project unit test suite via `npm test` and all tests completed successfully. 
- Ran linter via `npm run lint` with no errors reported. 
- Executed automated smoke checks for feature toggle flows which passed without regressions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bb1fdf44908330b473fceacd24e1c1)