### PR TITLE
Prefer internal chat API for AntiAFK messages to avoid input flash

### DIFF
--- a/Waddle.user.js
+++ b/Waddle.user.js
@@ -1075,7 +1075,21 @@ document.title = `🐧 Waddle v${SCRIPT_VERSION}`;
     return active.tagName === 'INPUT' || active.tagName === 'TEXTAREA' || active.isContentEditable;
   }
 
+  function sendChatMessage(text) {
+    try {
+      const game = gameRef.get();
+      if (!game?.chat) return false;
+      if (typeof game.chat.setInputValue !== 'function') return false;
+      if (typeof game.chat.submit !== 'function') return false;
+      game.chat.setInputValue(text);
+      game.chat.submit();
+      return true;
+    } catch (_) { return false; }
+  }
+
   function sendAfkChatMessage(text) {
+    if (sendChatMessage(text)) return;
+
     const game = gameRef.get();
     if (game?.chat) {
       for (const method of ['sendMessage', 'sendChat', 'send', 'submitMessage', 'submitChat']) {


### PR DESCRIPTION
### Motivation
- Reduce visible chat-box flashing when the AntiAFK feature posts messages by using the game's internal chat API when available.

### Description
- Add `sendChatMessage(text)` helper that calls `game.chat.setInputValue(text)` and `game.chat.submit()` and returns a boolean indicating success.
- Update `sendAfkChatMessage(text)` to call `sendChatMessage(text)` first and return early on success while retaining existing `game.chat` method checks and the DOM input fallbacks.

### Testing
- Ran `node --check Waddle.user.js` which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c9292dfc548330a2d5a47595fba7e4)