### PR TITLE
Fix Auto Anti-AFK to avoid showing toasts in menus

### DIFF
--- a/Waddle.user.js
+++ b/Waddle.user.js
@@ -255,23 +255,29 @@ document.title = `🐧 Waddle v${SCRIPT_VERSION}`;
     },
 
     _onTriggered() {
-  if (afkDetector._triggered) return;
-  afkDetector._triggered = true;
-  afkDetector._graceUntil = Date.now() + 2000;
-  showToast('Auto Anti-AFK', 'enabled', 'You went idle, Anti-AFK enabled');
-  if (afkSettings.sendChat && document.pointerLockElement) {
-    sendAfkChatMessage('I am currently AFK. I will be back shortly!'); 
-  }
-  afkDetector._wasOff = !state.features.antiAfk;
-  if (afkDetector._wasOff) setAfkActive(true);
-},
+      if (afkDetector._triggered) return;
+      if (!document.pointerLockElement) {
+        afkDetector._resetTimer();
+        return;
+      }
+      afkDetector._triggered = true;
+      afkDetector._graceUntil = Date.now() + 2000;
+      showToast('Auto Anti-AFK', 'enabled', 'You went idle, Anti-AFK enabled');
+      if (afkSettings.sendChat) {
+        sendAfkChatMessage('I am currently AFK. I will be back shortly!');
+      }
+      afkDetector._wasOff = !state.features.antiAfk;
+      if (afkDetector._wasOff) setAfkActive(true);
+    },
 
     _onReturn() {
       if (!afkDetector._triggered) return;
       afkDetector._triggered = false;
       if (afkDetector._wasOff) {
         setAfkActive(false);
-        showToast('Auto Anti-AFK', 'disabled', 'Welcome back, Anti-AFK disabled'); // TODO: Do not make the toast show In Menu (ONLY SHOW IN GAME)
+        if (document.pointerLockElement) {
+          showToast('Auto Anti-AFK', 'disabled', 'Welcome back, Anti-AFK disabled');
+        }
       }
       afkDetector._wasOff = false;
     },


### PR DESCRIPTION
### Motivation
- Prevent the Auto Anti-AFK feature from activating while the player is in menus (not actively in-game) and showing toasts there. 
- Keep the idle timer running when the trigger would otherwise fire outside gameplay so the detector stays functional once the player returns. 
- Only show the "Welcome back" toast when the player is still in-game to avoid noisy UI while menuing.

### Description
- Guard `afkDetector._onTriggered` with a check for `document.pointerLockElement` and `return` early while also calling `afkDetector._resetTimer()` to keep the idle timer alive when not in-game. 
- Simplified the AFK chat send condition now that `_onTriggered` only proceeds while in-game by removing the explicit `pointerLockElement` check from the chat-send branch. 
- In `afkDetector._onReturn`, only call `showToast('Auto Anti-AFK', 'disabled', ...)` when `document.pointerLockElement` is true so the toast is not shown when returning to the menu. 
- Minor formatting and indentation cleanup around the modified `afkDetector` methods in `Waddle.user.js`.

### Testing
- Ran `node --check Waddle.user.js` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca784b5a4083309296e558af56d451)