### PR TITLE
Refactor HUD setup and LRU cache to reduce boilerplate

### DIFF
--- a/Waddle.user.js
+++ b/Waddle.user.js
@@ -566,13 +566,12 @@ document.title = `🐧 Waddle v${SCRIPT_VERSION}`;
   }
 
   function initHudCanvas() {
-    if (document.getElementById('wb-hud-canvas')) return;
-    const canvas = el('canvas');
-    canvas.id = 'wb-hud-canvas';
-    canvas.width = window.innerWidth;
-    canvas.height = window.innerHeight;
+    const canvas = document.getElementById('wb-hud-canvas') || Object.assign(el('canvas'), { id: 'wb-hud-canvas' });
+    if (canvas.parentNode) return;
+    const resize = () => Object.assign(canvas, { width: window.innerWidth, height: window.innerHeight });
+    resize();
     document.body.appendChild(canvas);
-    state._resizeHandler = () => { canvas.width = window.innerWidth; canvas.height = window.innerHeight; };
+    state._resizeHandler = resize;
     window.addEventListener('resize', state._resizeHandler, { passive: true });
   }
 
@@ -582,8 +581,7 @@ document.title = `🐧 Waddle v${SCRIPT_VERSION}`;
       if (!this._map.has(key)) return undefined;
       const val = this._map.get(key);
       this._map.delete(key);
-      this._map.set(key, val);
-      return val;
+      return this._map.set(key, val).get(key);
     }
     set(key, val) {
       if (this._map.has(key)) this._map.delete(key);
@@ -619,9 +617,7 @@ document.title = `🐧 Waddle v${SCRIPT_VERSION}`;
     let needsRedraw = true;
 
     function clearHUD(resetNearest = false) {
-      if (lastDrawnType !== '' || resetNearest) {
-        ctx.clearRect(0, 0, canvas.width, canvas.height);
-      }
+      if (lastDrawnType || resetNearest) ctx.clearRect(0, 0, canvas.width, canvas.height);
       lastDrawnType = '';
       needsRedraw = true;
       if (resetNearest) cachedNearest = null;
@@ -630,10 +626,9 @@ document.title = `🐧 Waddle v${SCRIPT_VERSION}`;
     function findEntityMapKey(world) {
       if (entityMapKey && world[entityMapKey] instanceof Map) return entityMapKey;
       for (const [k, v] of Object.entries(world)) {
-        if (v instanceof Map && v.size > 0) {
-          const first = v.values().next().value;
-          if (first && typeof first.getHealth === 'function' && first.pos) { entityMapKey = k; return k; }
-        }
+        if (!(v instanceof Map) || v.size === 0) continue;
+        const first = v.values().next().value;
+        if (first && typeof first.getHealth === 'function' && first.pos) return (entityMapKey = k);
       }
       return null;
     }
@@ -670,11 +665,10 @@ document.title = `🐧 Waddle v${SCRIPT_VERSION}`;
     const DOM_QUERY_INTERVAL = 500;
 
     function getDOM(now) {
-      if (now - domQueryAge > DOM_QUERY_INTERVAL) {
-        domFaceEl = document.querySelector('.css-1pj0jj0 img');
-        domNameEl = document.querySelector('.css-1pj0jj0 p');
-        domQueryAge = now;
-      }
+      if (now - domQueryAge <= DOM_QUERY_INTERVAL) return;
+      domFaceEl = document.querySelector('.css-1pj0jj0 img');
+      domNameEl = document.querySelector('.css-1pj0jj0 p');
+      domQueryAge = now;
     }
 
     function drawEntityHUD(faceSrc, faceName) {


### PR DESCRIPTION
### Motivation
- Reduce repeated boilerplate in the HUD setup and helper utilities while preserving existing behavior.  
- Make resize and DOM-query logic more concise and easier to read.  
- Keep LRU promotion semantics intact while tightening map operations.

### Description
- Simplified `initHudCanvas()` to reuse an existing canvas lookup, centralize sizing into a single `resize` function, and reuse that function as the resize handler.  
- Rewrote `LRUCache#get()` to avoid a separate `set` call followed by returning the previously retrieved value while preserving delete+reinsert LRU promotion.  
- Shortened `clearHUD()` to use a compact conditional expression for clearing the canvas.  
- Streamlined `findEntityMapKey()` and `getDOM()` with early returns and tighter conditions to reduce lines without changing logic.

### Testing
- Ran `node --check Waddle.user.js` to verify there are no syntax errors, and the check passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd64588f7483309cbcf008bb85528f)